### PR TITLE
Fixes upper dependency ranges to allow usage of newer versions of stdlib and concat

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,8 +19,8 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0 <= 6.0.0"},
     {"name":"puppetlabs/vcsrepo","version_requirement":">= 1.0.0 < 5.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.2.5 < 5.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 1.2.5 <= 6.0.0"}
   ]
 }


### PR DESCRIPTION
This may allow one to use the module with recent stdlib and concat versions (ie > 5.0.0)